### PR TITLE
fix(vscode): validate `workspace` in `vscode` package

### DIFF
--- a/.changeset/seven-camels-live.md
+++ b/.changeset/seven-camels-live.md
@@ -1,0 +1,6 @@
+---
+"@dbf/core": minor
+"@dbf/vscode": patch
+---
+
+Validate `workspace` folders in `vscode` package as it's specific feature

--- a/packages/core/src/functions.ts
+++ b/packages/core/src/functions.ts
@@ -1,8 +1,8 @@
 import type { GenerationConfig } from './types.js';
 
 import { minimatch } from 'minimatch';
-import { readdirSync, statSync } from 'node:fs';
-import { join, posix, sep } from 'node:path';
+import { readdirSync } from 'node:fs';
+import { posix, sep } from 'node:path';
 
 import { FILE_REGEX } from './constants.js';
 
@@ -76,9 +76,6 @@ export const matchesGlob = (fileName: string, glob: string) =>
  */
 export const fileSort = (a: string, b: string): number =>
   a < b ? -1 : a > b ? 1 : 0;
-
-export const hasFolders = (path: string) =>
-  readdirSync(path).some(item => statSync(join(path, item)).isDirectory());
 
 /**
  * Checks if the given `posixPath` is a dart file, it has a different

--- a/packages/vscode/src/extension.mts
+++ b/packages/vscode/src/extension.mts
@@ -50,12 +50,16 @@ export const init = async (uri: Uri, type: GenerationType) => {
     throw new Error('The workspace has no folders');
   }
 
+  const workspaceDir = toPosixPath(workspace.workspaceFolders[0].uri.fsPath);
+  if (!toPosixPath(uri.fsPath).includes(workspaceDir)) {
+    throw new Error('Select a folder from the workspace');
+  }
+
   try {
     const result = await Context.start({
       fsPath: uri.fsPath,
       path: uri.path,
-      type,
-      workspace: toPosixPath(workspace.workspaceFolders[0].uri.fsPath)
+      type
     });
 
     if (result) {


### PR DESCRIPTION
Generating files from a workspace is a limitation that should not be handled in
the `core` package.
